### PR TITLE
Fix incremental_json test on travis

### DIFF
--- a/tests/incremental_json/test.sh
+++ b/tests/incremental_json/test.sh
@@ -5,12 +5,12 @@ printf "\nInitial status:\n"
 $FLOW status --no-auto-start --old-output-format .
 
 printf "\nCreate data.json:\n"
-cp data.json{1,}
+cp data.json1 data.json
 $FLOW force-recheck --no-auto-start test.js
 $FLOW status --no-auto-start . --old-output-format
 
 printf "\nModify data.json:\n"
-cp data.json{2,}
+cp data.json2 data.json
 $FLOW force-recheck --no-auto-start test.js
 $FLOW status --no-auto-start . --old-output-format
 


### PR DESCRIPTION
not sure why these seem to be escaped in whatever shell travis is running, but can work around it without knowing exactly why
